### PR TITLE
Update for new pymodbus module

### DIFF
--- a/solark_monitor/solark_monitor.py
+++ b/solark_monitor/solark_monitor.py
@@ -10,9 +10,10 @@ import sys
 import time
 import MySQLdb
 
-from pymodbus.client.sync import ModbusSerialClient, ModbusTcpClient
+from pymodbus.client import ModbusSerialClient, ModbusTcpClient
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
+# edit the solark_modbus_example.py to fit your needs, copy and rename it to solark_modbus.py
 from solark_modbus import register_table
 
 import config


### PR DESCRIPTION
Drop .sync ModbusSerialClient, ModbusTcpClient are now under pymodbus.client
Add comment/note about solark_modbus.py file