### PR TITLE
[0.7.1] - 2025-11-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [0.7.1] - 2025-11-06
+### Changed
+- Improved error handling in `build_register_dict()` to check for None returns from `read_register()`
+- Enhanced `connect_solark()` to explicitly return None on connection failures with better validation
+- Added connection validation in `solark()` function to prevent operations on failed connections
+### Fixed
+- Fixed AttributeError crash when Modbus connection fails (prevents calling decode methods on None)
+
+
 ## [0.7.0] - 2025-10-22
 ### Changed
 - Updated Python version from 3.11 to 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "solark_monitor"
-version = "0.7.0"
+version = "0.7.1"
 description = "A Python script to read memory register(s) from Sol-Ark Inverters and insert them into a database."
 authors = ["Aaron Melton <aaron@aaronmelton.com>"]
 

--- a/solark_monitor/config.py
+++ b/solark_monitor/config.py
@@ -18,11 +18,11 @@ class Config:
         """Application Variables."""
         self.app_dict = {
             "author": "Aaron Melton <aaron@aaronmelton.com>",
-            "date": "2025-10-22",
+            "date": "2025-11-06",
             "desc": "A Python script to read memory register(s) from Sol-Ark Inverters and insert them into a database.",
             "title": "solark_monitor",
             "url": "https://github.com/aaronmelton/solark_monitor",
-            "version": "0.7.0",
+            "version": "0.7.1",
         }
 
         # Logging Variables


### PR DESCRIPTION
## [0.7.1] - 2025-11-06
### Changed
- Improved error handling in `build_register_dict()` to check for None returns from `read_register()`
- Enhanced `connect_solark()` to explicitly return None on connection failures with better validation
- Added connection validation in `solark()` function to prevent operations on failed connections
### Fixed
- Fixed AttributeError crash when Modbus connection fails (prevents calling decode methods on None)
